### PR TITLE
HL-13810: overriding the sendToLog function

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,3 +1,5 @@
+## 3.1.1
+* Updating logger override to apply to the prototype method.
 ## 3.1.0
 * Adding a public api to allow customization of supertype's logging functionality.
 ## 3.0.0

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "supertype",
-    "version": "3.1.0",
+    "version": "3.1.1",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "supertype",
     "description": "A type system for classical inheritence, mix-ins and composition.",
-    "version": "3.1.0",
+    "version": "3.1.1",
     "main": "dist/index.js",
     "types": "dist/index.d.ts",
     "homepage": "https://github.com/haven-life/supertype",

--- a/src/SupertypeLogger.ts
+++ b/src/SupertypeLogger.ts
@@ -63,6 +63,7 @@ export class SupertypeLogger {
      */
     setLogger(loggerFunction: LoggerFunction) {
         this.sendToLog = loggerFunction;
+        SupertypeLogger.prototype.sendToLog = loggerFunction;
     }
 
     // Log all arguments assuming the first one is level and the second one might be an object (similar to banyan)
@@ -200,10 +201,10 @@ export class SupertypeLogger {
     prettyPrint(level, json) {
         let split = this.split(json, {time: 1, msg: 1, level: 1, name: 1});
 
-        return this.formatDateTime(new Date(json.time)) + ': ' + 
-                                    level.toUpperCase() + ': ' + 
-                                    addColonIfToken(split[1].name, ': ') + 
-                                    addColonIfToken(split[1].msg, ': ') + 
+        return this.formatDateTime(new Date(json.time)) + ': ' +
+                                    level.toUpperCase() + ': ' +
+                                    addColonIfToken(split[1].name, ': ') +
+                                    addColonIfToken(split[1].msg, ': ') +
                                     xy(split[0]);
 
         function addColonIfToken (token, colonAndSpace) {


### PR DESCRIPTION
This is to handle an issue where `amorphicStatic.logger.createChildLogger` is not applying the logger passed in during an `amorphic.listen`

If the preferred way is actually update the amorphicStatic.logger, I would be up for making that change if we can find out we can override amorphicStatic's logger with the passed in function.
