### PR TITLE
Swat/feature/hl 14832 enable statsd client passing

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,3 +1,5 @@
+## 3.2.0
+* Adding a statsd client property on base object template.
 ## 3.1.0
 * Adding a public api to allow customization of supertype's logging functionality.
 ## 3.0.0

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "supertype",
-    "version": "3.1.0",
+    "version": "3.2.0",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,9 +17,9 @@
             "dev": true
         },
         "@types/node": {
-            "version": "7.0.5",
-            "resolved": "https://registry.npmjs.org/@types/node/-/node-7.0.5.tgz",
-            "integrity": "sha1-lqDwphi3tgbx7FR0A8AGUCEL+7c=",
+            "version": "11.13.10",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-11.13.10.tgz",
+            "integrity": "sha512-leUNzbFTMX94TWaIKz8N15Chu55F9QSH+INKayQr5xpkasBQBRF3qQXfo3/dOnMU/dEIit+Y/SU8HyOjq++GwA==",
             "dev": true
         },
         "@types/reflect-metadata": {

--- a/package.json
+++ b/package.json
@@ -12,14 +12,14 @@
     "devDependencies": {
         "@types/chai": "^3.4.34",
         "@types/mocha": "^2.2.39",
-        "@types/node": "^7.0.5",
+        "@types/node": "^11.11.6",
         "chai": "*",
         "eslint": "3.7.x",
         "istanbul": "0.4.5",
-        "sinon": "1.15.x",
-        "typescript": "2.9.2",
         "mocha": "5.2.0",
-        "ts-node": "*"
+        "sinon": "1.15.x",
+        "ts-node": "*",
+        "typescript": "2.9.2"
     },
     "scripts": {
         "lint": "eslint .",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "supertype",
     "description": "A type system for classical inheritence, mix-ins and composition.",
-    "version": "3.1.0",
+    "version": "3.2.0",
     "main": "dist/index.js",
     "types": "dist/index.d.ts",
     "homepage": "https://github.com/haven-life/supertype",

--- a/src/ObjectTemplate.ts
+++ b/src/ObjectTemplate.ts
@@ -1,5 +1,6 @@
 import * as serializer from './serializer';
 import { SupertypeLogger } from './SupertypeLogger';
+import { StatsdClientInterface } from './StatsdClientInterface';
 export type CreateTypeForName = {
     name?: string;
     toClient?: boolean;
@@ -121,8 +122,34 @@ export class ObjectTemplate {
     static __templateUsage__: any;
     static __injections__: Function[];
     static __toClient__: boolean;
-
+    static __statsdClient__: StatsdClientInterface;
     static amorphicStatic = ObjectTemplate;
+
+    /**
+     * Gets the statsDClient
+     *
+     * The statsDClient may be on the amorphic object, but it will always
+     * redirect instead to the statsReference on amorphicStatic
+     *
+     * @static
+     * @type {(StatsDClient | undefined)}
+     * @memberof ObjectTemplate
+     */
+    static get statsdClient(): StatsdClientInterface {
+        return this.amorphicStatic.__statsdClient__;
+    }
+
+    /**
+     * Sets the statsDClient reference on amorphicStatic
+     *
+     * @static
+     * @type {(StatsDClient | undefined)}
+     * @memberof ObjectTemplate
+     */
+    static set statsdClient(statsClient: StatsdClientInterface) {
+        this.amorphicStatic.__statsdClient__ = statsClient;
+    }
+
     /**
      * Purpose unknown
      */

--- a/src/StatsdClientInterface.ts
+++ b/src/StatsdClientInterface.ts
@@ -1,0 +1,4 @@
+export interface StatsdClientInterface {
+    timing(statsKey: string, timer: number | Date, tags?: object): void,
+    counter(statsKey: string, num: number, tags?: object): void
+}

--- a/src/StatsdHelper.ts
+++ b/src/StatsdHelper.ts
@@ -1,0 +1,39 @@
+import { SupertypeSession } from './index';
+
+// format for hrtime
+// https://nodejs.org/api/process.html#process_process_hrtime_time
+type hrTime = [number, number];
+
+/**
+ * mostly static utility functions to assist supertype in handling statsd operations
+ */
+export class StatsdHelper {
+
+    /**
+     * convert node time format hrtime to milliseconds
+     * @param {hrTime} hrTime
+     * @returns {number}
+     */
+    public static convertHRTimeToMilliseconds(hrTime: hrTime): number {
+        return hrTime[0] * 1000 + hrTime[1] / 1000000;
+    }
+
+    /**
+     * given a start time and a key, record the total amount of time and send stat info.
+     * @param {hrTime} hrTimeStart
+     * @param {string} statsKey
+     * @param tags
+     */
+    public static computeTimingAndSend(hrTimeStart: hrTime, statsKey: string, tags?): void {
+        const statsdClient = SupertypeSession.statsdClient;
+
+        if(statsdClient
+            && statsdClient.timing
+            && typeof statsdClient.timing === 'function') {
+
+            const timerEndTime = process.hrtime(hrTimeStart);
+            const totalTimeInMilliseconds = this.convertHRTimeToMilliseconds(timerEndTime);
+            statsdClient.timing(statsKey, totalTimeInMilliseconds, tags);
+        }
+    }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -18,19 +18,18 @@
  OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
  WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
-/*
- * ObjectTemplate - n Type System with Benefits
- */
 
-import {ObjectTemplate} from './ObjectTemplate';
+import { ObjectTemplate } from './ObjectTemplate';
 
 ObjectTemplate.init();
 export default ObjectTemplate;
 
 let amorphicStatic = ObjectTemplate.amorphicStatic;
 let SupertypeSession = ObjectTemplate.amorphicStatic;
+export { StatsdClientInterface } from './StatsdClientInterface';
+export { StatsdHelper } from './StatsdHelper';
 
-export {amorphicStatic, SupertypeSession};
-export {SupertypeLogger} from './SupertypeLogger';
-export {Supertype} from './Supertype';
-export {supertypeClass, property, remote} from './decorators';
+export { amorphicStatic, SupertypeSession };
+export { SupertypeLogger } from './SupertypeLogger';
+export { Supertype } from './Supertype';
+export { supertypeClass, property, remote } from './decorators';

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,7 +6,7 @@
     "lib": ["es2015", "es2017", "dom"],
     "noImplicitAny": false,
     "typeRoots": [
-      "../node_modules/@types"
+      "./node_modules/@types"
     ],
     "declaration": true,
     "declarationDir": "dist",


### PR DESCRIPTION
Goal: add placeholder statsd client property for the consumer to place their stats logging object onto.

what was done:
- Take @sshankar19 new object template properties and put into clean branch. 
- create statsd helper module so that amorphic subcomponents can use this utility to easily log stats.
- general cleanup